### PR TITLE
Add capabilities support to feedItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ Posts a new feeditem for a record.
 
 * `id`: Required. The ID of the parent this feed element is being posted to. This value can be the ID of a user, group, or record, or the string me to indicate the context user.
 * `text`: Required. The text of the post.
+* `capabilities`: Optional. An optional JSON set of capabilities for this Feed Item (API 31.0+ only)
+
+```js
+var id = '00580000005eABFAA2';
+var text = 'Post text';
+var capabilities = {'link': { "urlName":"My Link","url":"http://www.mylink.com"}};
+org.chatter.postFeedItem({id: id, text: text, capabilities: capabilities}, function(err, resp){});
+```
 
 ### postComment()
 

--- a/index.js
+++ b/index.js
@@ -93,6 +93,7 @@ module.exports = function(nforce, pluginName) {
         "feedElementType" : "FeedItem",
         "subjectId" : args.id
       }
+    if (args.capabilities) body.capabilities = args.capabilities;
     opts.method = 'POST';
     opts.body = JSON.stringify(body);
     return this._apiRequest(opts, opts.callback);


### PR DESCRIPTION
Support an optional capabilities argument to allow the user to pass JSON-structured Chatter capabilities to be appended to the feedItem such as 'link', etc.

[Capabilities](https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_responses_feed_element_capabilities.htm)

``` js
var id = '00580000005eABFAA2';
var text = 'Post text';
var capabilities = {'link': { "urlName":"My Link","url":"http://www.mylink.com"}};
org.chatter.postFeedItem({id: id, text: text, capabilities: capabilities}, function(err, resp){});
```
